### PR TITLE
Add logging and harden clipboard failure handling

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4328,6 +4328,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -6473,6 +6474,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,6 +61,7 @@ tauri-plugin-deep-link = { path = "libs/deep-link", version = "0.1.2" }
 
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
+tracing-appender = "0.2.3"
 dirs = "5.0.0"
 diesel = { version = "2.1.4", features = ["sqlite", "chrono", "r2d2", "64-column-tables"] }
 

--- a/src-tauri/src/clipboard/mod.rs
+++ b/src-tauri/src/clipboard/mod.rs
@@ -298,7 +298,7 @@ where
       "clipboard://clipboard-monitor/update/error",
       error.to_string(),
     );
-    eprintln!("Error: {}", error);
+    tracing::error!("Clipboard monitor error: {}", error);
     CallbackResult::Next
   }
 }
@@ -311,18 +311,18 @@ pub struct ClipboardManager {
 
 impl ClipboardManager {
   pub fn read_text(&self) -> Result<String, String> {
-    let mut clipboard = Clipboard::new().unwrap();
+    let mut clipboard = Clipboard::new().map_err(|err| err.to_string())?;
     clipboard.get_text().map_err(|err| err.to_string())
   }
 
   pub fn write_text(&self, text: String) -> Result<(), String> {
-    let mut clipboard = Clipboard::new().unwrap();
+    let mut clipboard = Clipboard::new().map_err(|err| err.to_string())?;
     clipboard.set_text(text).map_err(|err| err.to_string())
   }
 
   // write_image function remains unchanged as it's writing, not reading
   pub fn write_image(&self, base64_image: String) -> Result<(), String> {
-    let mut clipboard = Clipboard::new().unwrap();
+    let mut clipboard = Clipboard::new().map_err(|err| err.to_string())?;
     let decoded = general_purpose::STANDARD_NO_PAD
       .decode(base64_image)
       .map_err(|err| err.to_string())?;
@@ -345,7 +345,7 @@ impl ClipboardManager {
   }
 
   pub fn read_image(&self) -> Result<String, String> {
-    let mut clipboard = Clipboard::new().unwrap();
+    let mut clipboard = Clipboard::new().map_err(|err| err.to_string())?;
     let image = clipboard.get_image().map_err(|err| err.to_string())?;
 
     // Handle stride alignment
@@ -401,7 +401,7 @@ impl ClipboardManager {
 
   // Function 2: Returns Vec<u8> of PNG file data
   pub fn read_image_binary(&self) -> Result<Vec<u8>, String> {
-    let mut clipboard = Clipboard::new().unwrap();
+    let mut clipboard = Clipboard::new().map_err(|err| err.to_string())?;
     let image = clipboard.get_image().map_err(|err| err.to_string())?;
 
     // Handle stride alignment

--- a/src-tauri/src/commands/clipboard_commands.rs
+++ b/src-tauri/src/commands/clipboard_commands.rs
@@ -86,20 +86,23 @@ pub struct TemplateOption {
 pub fn copy_text(app_handle: AppHandle, text: String) -> String {
   let mut manager = app_handle.clipboard_manager();
 
-  manager
-    .write_text(text)
-    .expect("failed to write to clipboard");
-
-  "ok".to_string()
+  match manager.write_text(text) {
+    Ok(_) => "ok".to_string(),
+    Err(err) => {
+      tracing::error!("Failed to write text to clipboard: {}", err);
+      "Failed to write to clipboard".to_string()
+    }
+  }
 }
 
 #[tauri::command]
 pub fn copy_paste(app_handle: AppHandle, text: String, delay: i32) -> String {
   let mut manager = app_handle.clipboard_manager();
 
-  manager
-    .write_text(text)
-    .expect("failed to write to clipboard");
+  if let Err(err) = manager.write_text(text) {
+    tracing::error!("Failed to write text to clipboard before paste: {}", err);
+    return "Failed to write to clipboard".to_string();
+  }
 
   #[cfg(target_os = "macos")]
   fn query_accessibility_permissions() -> bool {
@@ -140,7 +143,11 @@ pub fn copy_history_item(app_handle: AppHandle, history_id: String) -> String {
         match std::fs::read(&absolute_path) {
           Ok(img_data) => base64::encode(&img_data),
           Err(e) => {
-            eprintln!("Failed to read image from path: {}", e);
+            tracing::error!(
+              "Failed to read history image from {}: {}",
+              absolute_path.display(),
+              e
+            );
             IMAGE_NOT_FOUND_BASE64.to_string()
           }
         }
@@ -151,7 +158,7 @@ pub fn copy_history_item(app_handle: AppHandle, history_id: String) -> String {
     match write_image_to_clipboard(base64_image) {
       Ok(_) => "ok".to_string(),
       Err(e) => {
-        eprintln!("Failed to write image to clipboard: {}", e);
+        tracing::error!("Failed to write history image to clipboard: {}", e);
         "Failed to write image to clipboard".to_string()
       }
     }
@@ -164,7 +171,7 @@ pub fn copy_history_item(app_handle: AppHandle, history_id: String) -> String {
     match manager.write_text(value) {
       Ok(_) => "ok".to_string(),
       Err(e) => {
-        eprintln!("Failed to write to clipboard: {}", e);
+        tracing::error!("Failed to copy history value to clipboard: {}", e);
         "Failed to write to clipboard".to_string()
       }
     }
@@ -178,7 +185,7 @@ pub fn copy_paste_history_item(app_handle: AppHandle, history_id: String, delay:
 }
 
 pub fn write_image_to_clipboard(base64_image: String) -> Result<(), String> {
-  let mut clipboard = Clipboard::new().unwrap();
+  let mut clipboard = Clipboard::new().map_err(|err| err.to_string())?;
   let decoded = base64::decode(&base64_image).map_err(|err| err.to_string())?;
   let img = image::load_from_memory(&decoded).map_err(|err| err.to_string())?;
   let pixels = img
@@ -208,7 +215,7 @@ pub async fn copy_clip_item(
   let item = match get_item_by_id(item_id.clone()) {
     Ok(i) => i,
     Err(e) => {
-      eprintln!("Failed to find item: {}", e);
+      tracing::error!("Failed to find item {}: {}", item_id, e);
       return "Item not found".to_string();
     }
   };
@@ -249,20 +256,22 @@ pub async fn copy_clip_item(
               let settings_map = app_settings.lock().unwrap();
               let final_text = apply_global_templates(&filled_template, &settings_map);
 
-              manager
-                .write_text(&final_text)
-                .expect("Failed to write to clipboard");
-
-              "ok".to_string()
+              match manager.write_text(&final_text) {
+                Ok(_) => "ok".to_string(),
+                Err(err) => {
+                  tracing::error!("Failed to copy template output to clipboard: {}", err);
+                  "Failed to write to clipboard".to_string()
+                }
+              }
             }
             Err(e) => {
-              eprintln!("Failed to fill template: {}", e);
+              tracing::error!("Failed to fill template: {}", e);
               return "Failed to fill template".to_string();
             }
           }
         }
         Err(e) => {
-          eprintln!("Failed to deserialize template options: {}", e);
+          tracing::error!("Failed to deserialize template options: {}", e);
           return "Template options are not valid".to_string();
         }
       }
@@ -317,9 +326,10 @@ pub async fn copy_clip_item(
 
       match run_shell_command(command, exec_home_dir, output_template, output_regex_filter) {
         Ok(response) => {
-          manager
-            .write_text(&response)
-            .expect("Failed to write to clipboard");
+          if let Err(err) = manager.write_text(&response) {
+            tracing::error!("Failed to copy command output to clipboard: {}", err);
+            return "Failed to write to clipboard".to_string();
+          }
           handle_response(&app_handle, item_id.clone(), response);
           "ok".to_string()
         }
@@ -357,14 +367,15 @@ pub async fn copy_clip_item(
       match run_web_scraping(request).await {
         Ok(response) => {
           let content = response.scrapped_body.unwrap_or(response.body);
-          manager
-            .write_text(&content)
-            .expect("Failed to write to clipboard");
+          if let Err(err) = manager.write_text(&content) {
+            tracing::error!("Failed to copy scraping result to clipboard: {}", err);
+            return "Failed to write to clipboard".to_string();
+          }
           handle_response(&app_handle, item_id.clone(), content);
           "ok".to_string()
         }
         Err(e) => {
-          eprintln!("Web scraping failed: {}", e);
+          tracing::error!("Web scraping failed: {}", e);
           handle_response(
             &app_handle,
             item_id.clone(),
@@ -404,14 +415,15 @@ pub async fn copy_clip_item(
             return "Web request failed".to_string();
           }
 
-          manager
-            .write_text(&content)
-            .expect("Failed to write to clipboard");
+          if let Err(err) = manager.write_text(&content) {
+            tracing::error!("Failed to copy web request result to clipboard: {}", err);
+            return "Failed to write to clipboard".to_string();
+          }
           handle_response(&app_handle, item_id.clone(), content);
           "ok".to_string()
         }
         Err(e) => {
-          eprintln!("Web request failed: {}", e);
+          tracing::error!("Web request failed: {}", e);
           handle_response(
             &app_handle,
             item_id.clone(),
@@ -431,7 +443,11 @@ pub async fn copy_clip_item(
         match std::fs::read(&absolute_path) {
           Ok(img_data) => base64::encode(&img_data),
           Err(e) => {
-            eprintln!("Failed to read image from path: {}", e);
+            tracing::error!(
+              "Failed to read clip image from {}: {}",
+              absolute_path.display(),
+              e
+            );
             IMAGE_NOT_FOUND_BASE64.to_string()
           }
         }
@@ -442,7 +458,7 @@ pub async fn copy_clip_item(
     match write_image_to_clipboard(base64_image) {
       Ok(_) => "ok".to_string(),
       Err(e) => {
-        eprintln!("Failed to write image to clipboard: {}", e);
+        tracing::error!("Failed to write clip image to clipboard: {}", e);
         "Failed to write image to clipboard".to_string()
       }
     }
@@ -461,7 +477,7 @@ pub async fn copy_clip_item(
     match manager.write_text(final_text) {
       Ok(_) => "ok".to_string(),
       Err(e) => {
-        eprintln!("Failed to write to clipboard: {}", e);
+        tracing::error!("Failed to copy clip text to clipboard: {}", e);
         "Failed to write to clipboard".to_string()
       }
     }
@@ -486,7 +502,7 @@ pub async fn copy_paste_clip_item_from_menu(
     let item = match get_item_by_id(item_id.clone()) {
       Ok(i) => i,
       Err(e) => {
-        eprintln!("Failed to find item: {}", e);
+        tracing::error!("Failed to find item {}: {}", item_id, e);
         return "Item not found".to_string();
       }
     };
@@ -534,7 +550,7 @@ pub async fn copy_paste_clip_item(
   let item = match get_item_by_id(item_id.clone()) {
     Ok(i) => i,
     Err(e) => {
-      eprintln!("Failed to find item: {}", e);
+      tracing::error!("Failed to find item {}: {}", item_id, e);
       return "Item not found".to_string();
     }
   };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -48,6 +48,7 @@ use crate::commands::clipboard_commands::write_image_to_clipboard;
 use crate::menu::DbItems;
 use crate::models::Setting;
 use crate::services::history_service;
+use crate::services::logging;
 use crate::services::settings_service::get_all_settings;
 use crate::services::translations::translations::Translations;
 use crate::services::utils::remove_special_bbcode_tags;
@@ -875,11 +876,27 @@ async fn main() {
 
                 // Convert relative path to absolute path
                 let absolute_path = db::to_absolute_image_path(&image_path);
-                let img_data =
-                  std::fs::read(&absolute_path).expect("Failed to read image from path");
+                let img_data = match std::fs::read(&absolute_path) {
+                  Ok(data) => data,
+                  Err(err) => {
+                    tracing::error!(
+                      "Failed to read image from {}: {}",
+                      absolute_path.display(),
+                      err
+                    );
+                    return;
+                  }
+                };
                 let base64_image = base64::encode(&img_data);
 
-                write_image_to_clipboard(base64_image).expect("Failed to write image to clipboard");
+                if let Err(err) = write_image_to_clipboard(base64_image) {
+                  tracing::error!(
+                    "Failed to write image clipboard content for item {}: {}",
+                    item_id,
+                    err
+                  );
+                  return;
+                }
               }
               if item.is_link.unwrap_or(false) {
                 let url = item.value.as_deref().unwrap_or("");
@@ -890,9 +907,14 @@ async fn main() {
                   debug_output(|| {
                     println!("Copying URL to clipboard: {}", final_text);
                   });
-                  manager
-                    .write_text(final_text)
-                    .expect("failed to write to clipboard");
+                  if let Err(err) = manager.write_text(&final_text) {
+                    tracing::error!(
+                      "Failed to copy tray URL for item {} to clipboard: {}",
+                      item_id,
+                      err
+                    );
+                    return;
+                  }
                 } else {
                   let _ = opener::open(ensure_url_or_email_prefix(url))
                     .map_err(|e| format!("Failed to open url: {}", e));
@@ -906,9 +928,14 @@ async fn main() {
                   debug_output(|| {
                     println!("Copying path to clipboard: {}", final_text);
                   });
-                  manager
-                    .write_text(final_text)
-                    .expect("failed to write to clipboard");
+                  if let Err(err) = manager.write_text(&final_text) {
+                    tracing::error!(
+                      "Failed to copy tray path for item {} to clipboard: {}",
+                      item_id,
+                      err
+                    );
+                    return;
+                  }
                 } else {
                   let _ = opener::open(path).map_err(|e| format!("Failed to open path: {}", e));
                 }
@@ -919,9 +946,14 @@ async fn main() {
                   debug_output(|| {
                     println!("Copying item name to clipboard: {}", final_text);
                   });
-                  manager
-                    .write_text(final_text)
-                    .expect("failed to write to clipboard");
+                  if let Err(err) = manager.write_text(&final_text) {
+                    tracing::error!(
+                      "Failed to copy tray item name {} to clipboard: {}",
+                      item_id,
+                      err
+                    );
+                    return;
+                  }
                 } else if let Some(ref item_value) = item.value {
                   let text_to_copy = remove_special_bbcode_tags(item_value);
                   // Apply global templates
@@ -929,9 +961,14 @@ async fn main() {
                   debug_output(|| {
                     println!("Copying item value to clipboard: {}", final_text);
                   });
-                  manager
-                    .write_text(final_text)
-                    .expect("failed to write to clipboard");
+                  if let Err(err) = manager.write_text(&final_text) {
+                    tracing::error!(
+                      "Failed to copy tray item value {} to clipboard: {}",
+                      item_id,
+                      err
+                    );
+                    return;
+                  }
                 }
               }
 
@@ -1021,11 +1058,27 @@ async fn main() {
 
                 // Convert relative path to absolute path
                 let absolute_path = db::to_absolute_image_path(&image_path);
-                let img_data =
-                  std::fs::read(&absolute_path).expect("Failed to read image from path");
+                let img_data = match std::fs::read(&absolute_path) {
+                  Ok(data) => data,
+                  Err(err) => {
+                    tracing::error!(
+                      "Failed to read history image from {}: {}",
+                      absolute_path.display(),
+                      err
+                    );
+                    return;
+                  }
+                };
                 let base64_image = base64::encode(&img_data);
 
-                write_image_to_clipboard(base64_image).expect("Failed to write image to clipboard");
+                if let Err(err) = write_image_to_clipboard(base64_image) {
+                  tracing::error!(
+                    "Failed to copy history image {} to clipboard: {}",
+                    item_id,
+                    err
+                  );
+                  return;
+                }
               } else {
                 let value = match detailed_history_item.value {
                   Some(val) => val,
@@ -1033,9 +1086,14 @@ async fn main() {
                 };
                 // Apply global templates
                 let final_text = apply_global_templates(&value, &settings_map);
-                manager
-                  .write_text(final_text)
-                  .expect("failed to write to clipboard");
+                if let Err(err) = manager.write_text(&final_text) {
+                  tracing::error!(
+                    "Failed to copy history item {} to clipboard: {}",
+                    item_id,
+                    err
+                  );
+                  return;
+                }
               }
 
               #[cfg(target_os = "windows")]
@@ -1157,6 +1215,12 @@ async fn main() {
       }
     })
     .setup(|app| {
+      let log_path = logging::init_logging(app);
+      logging::install_panic_hook(log_path.clone());
+      if let Some(path) = log_path.as_ref() {
+        tracing::info!("Logging to {}", path.display());
+      }
+
       db::init(app);
       let app_settings = get_all_settings(None).unwrap_or_default();
       cron_jobs::setup_cron_jobs();

--- a/src-tauri/src/services/logging.rs
+++ b/src-tauri/src/services/logging.rs
@@ -1,0 +1,104 @@
+use once_cell::sync::OnceCell;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Once;
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+static LOG_GUARD: OnceCell<WorkerGuard> = OnceCell::new();
+static LOG_PATH: OnceCell<PathBuf> = OnceCell::new();
+static PANIC_HOOK: Once = Once::new();
+
+pub fn init_logging(app: &tauri::App) -> Option<PathBuf> {
+  if let Some(existing) = LOG_PATH.get() {
+    return Some(existing.clone());
+  }
+
+  let log_dir = match tauri::api::path::app_log_dir(&app.config()) {
+    Some(dir) => dir,
+    None => {
+      eprintln!("PasteBar: unable to determine application log directory");
+      return None;
+    }
+  };
+
+  if let Err(err) = fs::create_dir_all(&log_dir) {
+    eprintln!(
+      "PasteBar: failed to create log directory {}: {}",
+      log_dir.display(),
+      err
+    );
+    return None;
+  }
+
+  let log_file_path = log_dir.join("pastebar.log");
+
+  let file_appender = tracing_appender::rolling::daily(&log_dir, "pastebar.log");
+  let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+
+  let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+  let file_layer = fmt::layer().with_ansi(false).with_writer(non_blocking);
+  let stdout_layer = fmt::layer().with_ansi(cfg!(debug_assertions));
+
+  let subscriber = tracing_subscriber::registry()
+    .with(env_filter)
+    .with(file_layer)
+    .with(stdout_layer);
+
+  if let Err(err) = subscriber.try_init() {
+    eprintln!("PasteBar: failed to initialise logging: {}", err);
+    return None;
+  }
+
+  let _ = LOG_GUARD.set(guard);
+  let _ = LOG_PATH.set(log_file_path.clone());
+
+  tracing::info!(
+    "PasteBar logging initialised at {}",
+    log_file_path.display()
+  );
+
+  Some(log_file_path)
+}
+
+pub fn install_panic_hook(log_path: Option<PathBuf>) {
+  let log_hint = log_path.map(|path| path.display().to_string());
+
+  PANIC_HOOK.call_once(move || {
+    let hook_hint = log_hint.clone();
+    std::panic::set_hook(Box::new(move |info| {
+      let message = info
+        .payload()
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| info.payload().downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "Unknown panic".to_string());
+
+      let location = info
+        .location()
+        .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+        .unwrap_or_else(|| "unknown location".to_string());
+
+      let backtrace = std::backtrace::Backtrace::force_capture();
+
+      tracing::error!(
+        target: "panic",
+        message = %message,
+        location = %location,
+        backtrace = %backtrace,
+        "PasteBar encountered an unrecoverable error"
+      );
+
+      eprintln!("PasteBar panic at {location}: {message}\nBacktrace:\n{backtrace}");
+
+      if let Some(path) = &hook_hint {
+        eprintln!("Panic details were also logged to {path}");
+      }
+    }));
+  });
+}
+
+pub fn log_file_path() -> Option<PathBuf> {
+  LOG_PATH.get().cloned()
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod collections_service;
 pub mod history_service;
 pub mod items_service;
 pub mod link_metadata_service;
+pub mod logging;
 pub mod request_service;
 pub mod settings_service;
 pub mod shell_service;


### PR DESCRIPTION
## Summary
- add a tracing-based logging pipeline and panic hook so crashes get written to a file
- guard system tray and clipboard commands against clipboard write failures and log the errors instead of panicking
- ensure the internal clipboard manager handles initialization errors gracefully

## Testing
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: missing system dependency `glib-2.0` in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fbed1f24832180d31bd03f7722b5