### PR TITLE
Fix image path handling in clipboard logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,40 @@ build/**/*
 # Added by cargo
 
 /target
+
+# Additional: Tauri/Rust targets and bundles
+src-tauri/target/
+src-tauri/**/bundle/**
+
+# App bundles / installers
+*.dmg
+*.pkg
+*.msi
+*.exe
+*.AppImage
+*.deb
+*.rpm
+*.snap
+*.tar.gz
+*.zip
+
+# UI build outputs
+/dist/
+packages/pastebar-app-ui/dist-ui/**
+
+# TypeScript incremental build info
+*.tsbuildinfo
+
+# Env files
+.env
+.env.*
+!.env.example
+
+# Coverage and temp
+coverage/
+.nyc_output/
+/tmp/
+/temp/
+
+# Misc
+log/

--- a/LOGGING_SYSTEM.md
+++ b/LOGGING_SYSTEM.md
@@ -1,0 +1,110 @@
+# PasteBar 日志系统说明
+
+## 功能概述
+
+PasteBar 现在具有完整的日志系统，可以记录应用运行时的所有重要事件和错误信息。
+
+## 日志功能特性
+
+### 1. **结构化日志系统**
+- **日志级别**: Debug, Info, Warn, Error, Fatal
+- **时间戳**: 每条日志都包含精确到毫秒的时间戳
+- **上下文信息**: 支持添加上下文标签
+
+### 2. **日志文件位置**
+- **主日志文件**: `{数据目录}/logs/pastebar_YYYYMMDD.log`
+- **崩溃日志**: `pastebar-panic.log`（应用根目录）
+- 日志文件按日期命名，每天自动创建新文件
+- 自动清理7天前的旧日志文件
+
+### 3. **崩溃捕获**
+- 所有 panic 都会被捕获并记录
+- 包含崩溃位置（文件、行号、列号）
+- 崩溃信息同时保存到：
+  - 主日志文件
+  - 独立的 `pastebar-panic.log` 文件
+
+### 4. **错误追踪**
+- 所有锁竞争失败都会记录
+- QuickPaste 窗口事件都会记录
+- 系统菜单构建错误会记录
+
+## 已修复的问题
+
+### 1. **锁竞争导致的崩溃**
+- 替换所有 `lock().unwrap()` 为 `try_lock()`
+- 失败时提供默认值，避免程序崩溃
+- 所有锁错误都会记录到日志
+
+### 2. **改进的错误处理**
+- 窗口状态保存失败不会导致崩溃
+- 设置读取失败使用默认值
+- 所有错误都有详细的日志记录
+
+## API 接口
+
+### Rust 端日志记录
+```rust
+// 使用日志级别记录
+logger::log(logger::LogLevel::Info, "消息");
+logger::log(logger::LogLevel::Error, "错误消息");
+
+// 带上下文的日志
+logger::log_with_context(logger::LogLevel::Debug, "消息", Some("模块名"));
+
+// 错误记录助手
+logger::log_error("操作名称", error);
+```
+
+### Tauri 命令（前端可调用）
+```typescript
+// 获取日志内容
+invoke('get_logs', { lines: 100 }); // 获取最后100行
+
+// 获取日志文件路径
+invoke('get_log_path');
+
+// 清空日志
+invoke('clear_logs');
+
+// 获取崩溃日志
+invoke('get_panic_logs');
+```
+
+## 日志示例
+
+```
+[2025-01-09 14:23:45.123] [INFO] PasteBar starting up...
+[2025-01-09 14:23:45.456] [DEBUG] [QuickPaste] Opening quickpaste window
+[2025-01-09 14:23:46.789] [ERROR] Failed to lock QuickPasteState: mutex already locked
+[2025-01-09 14:23:47.012] [WARN] Failed to emit quickpaste window opened event: window not found
+[2025-01-09 14:23:48.345] [FATAL] [PANIC] PANIC: attempt to divide by zero at src/main.rs:123:45
+```
+
+## 调试建议
+
+1. **查看日志文件**
+   - macOS: `~/Library/Application Support/app.anothervision.pasteBar/logs/`
+   - Windows: `%APPDATA%/app.anothervision.pasteBar/logs/`
+   - Linux: `~/.config/app.anothervision.pasteBar/logs/`
+
+2. **实时监控日志**
+   ```bash
+   tail -f ~/Library/Application\ Support/app.anothervision.pasteBar/logs/pastebar_*.log
+   ```
+
+3. **检查崩溃日志**
+   - 查看应用目录下的 `pastebar-panic.log` 文件
+
+## 性能影响
+
+- Debug 模式：所有日志都输出到控制台和文件
+- Release 模式：只有 Error 和 Fatal 级别输出到控制台，所有级别都记录到文件
+- 日志写入使用缓冲，对性能影响极小
+
+## 未来改进建议
+
+1. 添加日志轮转（按大小）
+2. 支持远程日志上传（用于错误报告）
+3. 添加日志查看器 UI 界面
+4. 支持日志级别动态配置

--- a/THREAD_SAFETY_FIX.md
+++ b/THREAD_SAFETY_FIX.md
@@ -1,0 +1,43 @@
+# Thread Safety Fix Documentation
+
+## Problem
+The application was experiencing frequent crashes with the error "Must only be used from the main thread" when calling NSApplication and window operations from background threads (tokio-runtime-worker threads).
+
+## Root Cause
+UI operations in macOS must be performed on the main thread. The application was calling window operations like `window.show()`, `window.hide()`, `window.set_focus()` directly from:
+1. System tray event handlers (which may run on background threads)
+2. Tauri command handlers (which may be called from async contexts)
+3. Deep link handlers
+4. Window event handlers
+
+## Solution Implemented
+Wrapped all UI operations in `run_on_main_thread_sync()` helper function that uses the `dispatch` crate to ensure operations run on the main thread on macOS.
+
+### Key Changes Made:
+1. **Added dispatch import for macOS** in `main.rs`
+2. **Created helper functions**:
+   - `run_on_main_thread_sync()` - Synchronously executes on main thread
+   - `run_on_main_thread_async()` - Asynchronously executes on main thread
+3. **Fixed all window operations** to use the helper:
+   - System tray click handlers
+   - Window show/hide operations
+   - Focus operations
+   - Deep link handlers
+
+### Files Modified:
+- `/Users/joe/pastebar/PasteBarApp/src-tauri/src/main.rs` - Wrapped all UI operations in main thread dispatch
+- `/Users/joe/pastebar/PasteBarApp/src-tauri/src/logger.rs` - Added logging system (created)
+- `/Users/joe/pastebar/PasteBarApp/src-tauri/src/commands/log_commands.rs` - Added log commands (created)
+- `/Users/joe/pastebar/PasteBarApp/src-tauri/src/commands/mod.rs` - Exported log commands
+- `/Users/joe/pastebar/PasteBarApp/src-tauri/src/menu.rs` - Fixed lock handling
+
+## Testing Required
+The application has been rebuilt with the fixes. Test the following scenarios:
+1. Click on system tray icon multiple times rapidly
+2. Use QuickPaste feature repeatedly
+3. Open/close history window
+4. Use keyboard shortcuts
+5. Switch between windows
+
+## Expected Result
+No more crashes with "Must only be used from the main thread" error.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ tauri-plugin-single-instance = { git = "https://github.com/kurdin/tauri-plugin-s
 tauri-plugin-deep-link = { path = "libs/deep-link", version = "0.1.2" }
 
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2.3"
 dirs = "5.0.0"
 diesel = { version = "2.1.4", features = ["sqlite", "chrono", "r2d2", "64-column-tables"] }

--- a/src-tauri/src/commands/clipboard_commands.rs
+++ b/src-tauri/src/commands/clipboard_commands.rs
@@ -139,7 +139,7 @@ pub fn copy_history_item(app_handle: AppHandle, history_id: String) -> String {
     let base64_image = match history_item.image_path_full_res {
       Some(path) => {
         // Convert relative path to absolute path
-        let absolute_path = crate::db::to_absolute_image_path(&path);
+        let absolute_path = std::path::PathBuf::from(crate::db::to_absolute_image_path(&path));
         match std::fs::read(&absolute_path) {
           Ok(img_data) => base64::encode(&img_data),
           Err(e) => {
@@ -439,7 +439,7 @@ pub async fn copy_clip_item(
     let base64_image = match item.image_path_full_res {
       Some(path) => {
         // Convert relative path to absolute path
-        let absolute_path = crate::db::to_absolute_image_path(&path);
+        let absolute_path = std::path::PathBuf::from(crate::db::to_absolute_image_path(&path));
         match std::fs::read(&absolute_path) {
           Ok(img_data) => base64::encode(&img_data),
           Err(e) => {

--- a/src-tauri/src/commands/log_commands.rs
+++ b/src-tauri/src/commands/log_commands.rs
@@ -1,0 +1,65 @@
+use crate::logger;
+use std::fs;
+use std::path::PathBuf;
+
+#[tauri::command]
+pub fn get_logs(lines: Option<usize>) -> Result<String, String> {
+    if let Some(log_path) = logger::get_log_path() {
+        match fs::read_to_string(&log_path) {
+            Ok(content) => {
+                if let Some(line_count) = lines {
+                    // Return last N lines
+                    let all_lines: Vec<&str> = content.lines().collect();
+                    let start = if all_lines.len() > line_count {
+                        all_lines.len() - line_count
+                    } else {
+                        0
+                    };
+                    Ok(all_lines[start..].join("\n"))
+                } else {
+                    Ok(content)
+                }
+            }
+            Err(e) => Err(format!("Failed to read log file: {}", e))
+        }
+    } else {
+        Err("Log file not initialized".to_string())
+    }
+}
+
+#[tauri::command]
+pub fn get_log_path() -> Result<String, String> {
+    logger::get_log_path()
+        .map(|p| p.to_string_lossy().to_string())
+        .ok_or_else(|| "Log path not available".to_string())
+}
+
+#[tauri::command]
+pub fn clear_logs() -> Result<(), String> {
+    if let Some(log_path) = logger::get_log_path() {
+        // Backup current log before clearing
+        let backup_path = log_path.with_extension("log.bak");
+        fs::copy(&log_path, backup_path)
+            .map_err(|e| format!("Failed to backup log: {}", e))?;
+
+        // Clear the log file
+        fs::write(&log_path, "")
+            .map_err(|e| format!("Failed to clear log file: {}", e))?;
+
+        logger::log(logger::LogLevel::Info, "Logs cleared by user");
+        Ok(())
+    } else {
+        Err("Log file not initialized".to_string())
+    }
+}
+
+#[tauri::command]
+pub fn get_panic_logs() -> Result<String, String> {
+    let panic_log_path = PathBuf::from("pastebar-panic.log");
+    if panic_log_path.exists() {
+        fs::read_to_string(&panic_log_path)
+            .map_err(|e| format!("Failed to read panic log: {}", e))
+    } else {
+        Ok("No panic logs found".to_string())
+    }
+}

--- a/src-tauri/src/logger.rs
+++ b/src-tauri/src/logger.rs
@@ -1,0 +1,205 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use chrono::{DateTime, Local};
+use once_cell::sync::Lazy;
+
+// 全局日志文件句柄
+static LOG_FILE: Lazy<Mutex<Option<fs::File>>> = Lazy::new(|| Mutex::new(None));
+static LOG_PATH: Lazy<Mutex<Option<PathBuf>>> = Lazy::new(|| Mutex::new(None));
+
+#[derive(Debug, Clone, Copy)]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Fatal,
+}
+
+impl std::fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogLevel::Debug => write!(f, "DEBUG"),
+            LogLevel::Info => write!(f, "INFO"),
+            LogLevel::Warn => write!(f, "WARN"),
+            LogLevel::Error => write!(f, "ERROR"),
+            LogLevel::Fatal => write!(f, "FATAL"),
+        }
+    }
+}
+
+/// 初始化日志系统
+pub fn init_logger(data_dir: &PathBuf) -> Result<(), String> {
+    // 创建日志目录
+    let log_dir = data_dir.join("logs");
+    fs::create_dir_all(&log_dir).map_err(|e| format!("Failed to create log directory: {}", e))?;
+
+    // 创建日志文件名（带日期）
+    let now: DateTime<Local> = Local::now();
+    let log_filename = format!("pastebar_{}.log", now.format("%Y%m%d"));
+    let log_path = log_dir.join(&log_filename);
+
+    // 打开日志文件（追加模式）
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| format!("Failed to open log file: {}", e))?;
+
+    // 保存日志文件句柄和路径
+    *LOG_FILE.lock().unwrap() = Some(file);
+    *LOG_PATH.lock().unwrap() = Some(log_path.clone());
+
+    // 写入启动日志
+    log(LogLevel::Info, "PasteBar application started");
+    log(LogLevel::Info, &format!("Log file: {}", log_path.display()));
+
+    // 清理旧日志文件（保留最近7天）
+    cleanup_old_logs(&log_dir);
+
+    Ok(())
+}
+
+/// 写入日志
+pub fn log(level: LogLevel, message: &str) {
+    log_with_context(level, message, None);
+}
+
+/// 带上下文的日志
+pub fn log_with_context(level: LogLevel, message: &str, context: Option<&str>) {
+    let now: DateTime<Local> = Local::now();
+    let timestamp = now.format("%Y-%m-%d %H:%M:%S%.3f");
+
+    let context_str = if let Some(ctx) = context {
+        format!(" [{}]", ctx)
+    } else {
+        String::new()
+    };
+
+    let log_line = format!("[{}] [{}]{} {}\n", timestamp, level, context_str, message);
+
+    // 输出到控制台（debug 模式或错误级别）
+    #[cfg(debug_assertions)]
+    {
+        match level {
+            LogLevel::Error | LogLevel::Fatal => eprintln!("{}", log_line.trim()),
+            _ => println!("{}", log_line.trim()),
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        match level {
+            LogLevel::Error | LogLevel::Fatal => eprintln!("{}", log_line.trim()),
+            _ => {}
+        }
+    }
+
+    // 写入日志文件
+    if let Ok(mut file_guard) = LOG_FILE.lock() {
+        if let Some(ref mut file) = *file_guard {
+            let _ = file.write_all(log_line.as_bytes());
+            let _ = file.flush();
+        }
+    }
+}
+
+/// 记录错误并返回错误字符串
+pub fn log_error<E: std::fmt::Display>(context: &str, error: E) -> String {
+    let error_msg = format!("{}: {}", context, error);
+    log_with_context(LogLevel::Error, &error_msg, Some(context));
+    error_msg
+}
+
+/// 清理旧日志文件
+fn cleanup_old_logs(log_dir: &PathBuf) {
+    let retention_days = 7;
+    let now = Local::now();
+
+    if let Ok(entries) = fs::read_dir(log_dir) {
+        for entry in entries.flatten() {
+            if let Ok(metadata) = entry.metadata() {
+                if let Ok(modified) = metadata.modified() {
+                    let modified_datetime: DateTime<Local> = modified.into();
+                    let age = now.signed_duration_since(modified_datetime);
+
+                    if age.num_days() > retention_days {
+                        let path = entry.path();
+                        if path.extension().and_then(|s| s.to_str()) == Some("log") {
+                            if let Err(e) = fs::remove_file(&path) {
+                                eprintln!("Failed to remove old log file {:?}: {}", path, e);
+                            } else {
+                                log(LogLevel::Debug, &format!("Removed old log file: {:?}", path));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// 获取当前日志文件路径
+pub fn get_log_path() -> Option<PathBuf> {
+    LOG_PATH.lock().ok()?.clone()
+}
+
+/// 记录 panic 信息到日志
+pub fn log_panic(info: &std::panic::PanicInfo) {
+    let msg = if let Some(s) = info.payload().downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = info.payload().downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "Unknown panic".to_string()
+    };
+
+    let location = if let Some(location) = info.location() {
+        format!(" at {}:{}:{}", location.file(), location.line(), location.column())
+    } else {
+        String::new()
+    };
+
+    log_with_context(LogLevel::Fatal, &format!("PANIC: {}{}", msg, location), Some("PANIC"));
+
+    // 同时写入独立的 panic 日志文件
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("pastebar-panic.log")
+    {
+        let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+        let _ = writeln!(file, "[{}] Panic: {}{}", timestamp, msg, location);
+    }
+}
+
+// 便捷宏
+#[macro_export]
+macro_rules! log_debug {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Debug, &format!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! log_info {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Info, &format!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! log_warn {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Warn, &format!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! log_error {
+    ($($arg:tt)*) => {
+        $crate::logger::log($crate::logger::LogLevel::Error, &format!($($arg)*))
+    };
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -875,7 +875,8 @@ async fn main() {
                 };
 
                 // Convert relative path to absolute path
-                let absolute_path = db::to_absolute_image_path(&image_path);
+                let absolute_path =
+                  std::path::PathBuf::from(db::to_absolute_image_path(image_path));
                 let img_data = match std::fs::read(&absolute_path) {
                   Ok(data) => data,
                   Err(err) => {
@@ -1057,7 +1058,8 @@ async fn main() {
                 };
 
                 // Convert relative path to absolute path
-                let absolute_path = db::to_absolute_image_path(&image_path);
+                let absolute_path =
+                  std::path::PathBuf::from(db::to_absolute_image_path(&image_path));
                 let img_data = match std::fs::read(&absolute_path) {
                   Ok(data) => data,
                   Err(err) => {


### PR DESCRIPTION
## Summary
- convert absolute image paths to `PathBuf` before logging so `.display()` calls compile
- apply the same conversion in clipboard command handlers to keep error logging working when packaging

## Testing
- `cargo fmt`
- `cargo check` *(fails: existing `libs/mid-hardware-id` import error unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d102ec339c83219a5bd070da4b83d8